### PR TITLE
Fix typo in link's target.

### DIFF
--- a/07_RegressionModels/readme.html
+++ b/07_RegressionModels/readme.html
@@ -145,7 +145,7 @@ hr {
 <p>This is the readme file for the regression component of the set of data science modules</p>
 
 <ul>
-<li><a href="01_01_introduction/index.thml">Introduction</a></li>
+<li><a href="01_01_introduction/index.html">Introduction</a></li>
 <li><a href="01_02_notation/index.html">Notation</a></li>
 <li><a href="01_03_ols/index.html">Least squares</a></li>
 <li><a href="01_04_rttm/index.html">Regression to mediocrity</a></li>

--- a/07_RegressionModels/readme.md
+++ b/07_RegressionModels/readme.md
@@ -2,7 +2,7 @@
 
 This is the readme file for the regression component of the set of data science modules
 
-* [Introduction](01_01_introduction/index.thml)
+* [Introduction](01_01_introduction/index.html)
 * [Notation](01_02_notation/index.html)
 * [Least squares](01_03_ols/index.html)
 * [Regression to mediocrity](01_04_rttm/index.html)


### PR DESCRIPTION
Found a typo in the Regression Models README.
