### PR TITLE
Fixing typos: it's -> its

### DIFF
--- a/06_StatisticalInference/03_04_Power/index.Rmd
+++ b/06_StatisticalInference/03_04_Power/index.Rmd
@@ -16,7 +16,7 @@ mode        : selfcontained # {standalone, draft}
 
 ## Power
 - Power is the probability of rejecting the null hypothesis when it is false
-- Ergo, power (as it's name would suggest) is a good thing; you want more power
+- Ergo, power (as its name would suggest) is a good thing; you want more power
 - A type II error (a bad thing, as its name would suggest) is failing to reject the null hypothesis when it's false; the probability of a type II error is usually called $\beta$
 - Note Power  $= 1 - \beta$
 

--- a/06_StatisticalInference/11_Power/index.Rmd
+++ b/06_StatisticalInference/11_Power/index.Rmd
@@ -16,7 +16,7 @@ mode        : selfcontained # {standalone, draft}
 
 ## Power
 - Power is the probability of rejecting the null hypothesis when it is false
-- Ergo, power (as it's name would suggest) is a good thing; you want more power
+- Ergo, power (as its name would suggest) is a good thing; you want more power
 - A type II error (a bad thing, as its name would suggest) is failing to reject the null hypothesis when it's false; the probability of a type II error is usually called $\beta$
 - Note Power  $= 1 - \beta$
 

--- a/06_StatisticalInference/homework/hw1.Rmd
+++ b/06_StatisticalInference/homework/hw1.Rmd
@@ -60,7 +60,7 @@ $$.15 = .10 + .09 - P(AB)$$
 
 ---  &radio
 
-A random variable, $X$, is uniform, a box from $0$ to $1$ of height $1$. (So that it's density is $f(x) = 1$ for $0\leq x \leq 1$.) What is it's median expressed to two decimal places? </p>
+A random variable, $X$, is uniform, a box from $0$ to $1$ of height $1$. (So that its density is $f(x) = 1$ for $0\leq x \leq 1$.) What is its median expressed to two decimal places? </p>
 
 1. 1.00
 2. 0.75


### PR DESCRIPTION
Fixing a few typos (it's -> its) in the 06_StatisticalInference course material.
