### PR TITLE
Amended the typo in R code for Regression through origin

### DIFF
--- a/07_RegressionModels/01_01_introduction/index.Rmd
+++ b/07_RegressionModels/01_01_introduction/index.Rmd
@@ -192,7 +192,7 @@ and children's heights
 y <- galton$child - mean(galton$child)
 x <- galton$parent - mean(galton$parent)
 freqData <- as.data.frame(table(x, y))
-names(freqData) <- c("child", "parent", "freq")
+names(freqData) <- c("parent", "child", "freq")
 freqData$child <- as.numeric(as.character(freqData$child))
 freqData$parent <- as.numeric(as.character(freqData$parent))
 myPlot <- function(beta){


### PR DESCRIPTION
Hi, 
There seems to be a typo in the R code for Regression through the origin. 
The first column of freqData should be parent instead of child based on this line 
"freqData <- as.data.frame(table(x, y))"
hence the following line should be "names(freqData) <- c("parent", "child", "freq")" 
instead of the original "names(freqData) <- c("child", "parent", "freq")"

For your review please. Thanks :)