### PR TITLE
06-statinference: min(mp, 1) instead of max(mp, 1)

### DIFF
--- a/06_StatisticalInference/12_MultipleTesting/index.Rmd
+++ b/06_StatisticalInference/12_MultipleTesting/index.Rmd
@@ -160,7 +160,7 @@ Controlling all error rates at $\alpha = 0.20$
 
 __Example__: 
 * Suppose P-values are $P_1,\ldots,P_m$
-* You could adjust them by taking $P_i^{fwer} = \max{m \times P_i,1}$ for each P-value.
+* You could adjust them by taking $P_i^{fwer} = \min{m \times P_i,1}$ for each P-value.
 * Then if you call all $P_i^{fwer} < \alpha$ significant you will control the FWER. 
 
 ---

--- a/06_StatisticalInference/rmd/12_MultipleTesting.Rmd
+++ b/06_StatisticalInference/rmd/12_MultipleTesting.Rmd
@@ -160,7 +160,7 @@ Controlling all error rates at $\alpha = 0.20$
 
 __Example__: 
 * Suppose P-values are $P_1,\ldots,P_m$
-* You could adjust them by taking $P_i^{fwer} = \max{m \times P_i,1}$ for each P-value.
+* You could adjust them by taking $P_i^{fwer} = \min{m \times P_i,1}$ for each P-value.
 * Then if you call all $P_i^{fwer} < \alpha$ significant you will control the FWER. 
 
 ---


### PR DESCRIPTION
max(mp,1) might get larger than 1. It should be min(mp,1)
Ref: https://class.coursera.org/statinference-011/forum/thread?thread_id=153