### PR TITLE
Replaced x1, x2 with g1, g2 respectively.

### DIFF
--- a/06_StatisticalInference/08_tCIs/index.Rmd
+++ b/06_StatisticalInference/08_tCIs/index.Rmd
@@ -178,8 +178,7 @@ sp <- sqrt((7 * 15.34^2 + 20 * 18.23^2) / (8 + 21 - 2))
 ## Mistakenly treating the sleep data as grouped
 ```{r}
 n1 <- length(g1); n2 <- length(g2)
-x1 <- sd(g1); x2 <-sd(g2)
-sp <- sqrt( ((n1 - 1) * sd(x1)^2 + (n2-1) * sd(x2)^2) / (n1 + n2-2))
+sp <- sqrt( ((n1 - 1) * sd(g1)^2 + (n2-1) * sd(g2)^2) / (n1 + n2-2))
 md <- mean(g2) - mean(g1)
 semd <- sp * sqrt(1 / n1 + 1/n2)
 rbind(

--- a/06_StatisticalInference/08_tCIs/index.Rmd
+++ b/06_StatisticalInference/08_tCIs/index.Rmd
@@ -178,6 +178,7 @@ sp <- sqrt((7 * 15.34^2 + 20 * 18.23^2) / (8 + 21 - 2))
 ## Mistakenly treating the sleep data as grouped
 ```{r}
 n1 <- length(g1); n2 <- length(g2)
+x1 <- sd(g1); x2 <-sd(g2)
 sp <- sqrt( ((n1 - 1) * sd(x1)^2 + (n2-1) * sd(x2)^2) / (n1 + n2-2))
 md <- mean(g2) - mean(g1)
 semd <- sp * sqrt(1 / n1 + 1/n2)


### PR DESCRIPTION
Under heading  ## Mistakenly treating the sleep data as grouped.