### PR TITLE
fix unpaired sleep data conf interval example

### DIFF
--- a/06_StatisticalInference/08_tCIs/index.html
+++ b/06_StatisticalInference/08_tCIs/index.html
@@ -320,7 +320,7 @@ t.test(extra ~ I(relevel(group, 2)), paired = TRUE, data = sleep)
   <article data-timings="">
     <pre><code class="r">n1 &lt;- length(g1)
 n2 &lt;- length(g2)
-sp &lt;- sqrt(((n1 - 1) * sd(x1)^2 + (n2 - 1) * sd(x2)^2)/(n1 + n2 - 2))
+sp &lt;- sqrt(((n1 - 1) * sd(g1)^2 + (n2 - 1) * sd(g2)^2)/(n1 + n2 - 2))
 </code></pre>
 
 <pre><code>## Error: object &#39;x1&#39; not found


### PR DESCRIPTION
Rename 'x1' and 'x2' to 'g1' and 'g2'.  Consistent variables names make this
example work and produce the same results (-0.203874  3.363874) as shown
in the slide.  It depends on code from the previous example that loads
the sleep dataset and prepares 'g1' and 'g2'.
