### PR TITLE
fix unpaired sleep data conf interval example

### DIFF
--- a/06_StatisticalInference/08_tCIs/index.Rmd
+++ b/06_StatisticalInference/08_tCIs/index.Rmd
@@ -178,7 +178,7 @@ sp <- sqrt((7 * 15.34^2 + 20 * 18.23^2) / (8 + 21 - 2))
 ## Mistakenly treating the sleep data as grouped
 ```{r}
 n1 <- length(g1); n2 <- length(g2)
-sp <- sqrt( ((n1 - 1) * sd(x1)^2 + (n2-1) * sd(x2)^2) / (n1 + n2-2))
+sp <- sqrt( ((n1 - 1) * sd(g1)^2 + (n2-1) * sd(g2)^2) / (n1 + n2-2))
 md <- mean(g2) - mean(g1)
 semd <- sp * sqrt(1 / n1 + 1/n2)
 rbind(

--- a/06_StatisticalInference/13_Resampling/index.Rmd
+++ b/06_StatisticalInference/13_Resampling/index.Rmd
@@ -173,7 +173,7 @@ g
 ## Permutation tests
 -  Consider the null hypothesis that the distribution of the observations from each group is the same
 -  Then, the group labels are irrelevant
-- Consider a data frome with count and spray
+- Consider a data frame with count and spray
 - Permute the spray (group) labels 
 - Recalculate the statistic
   - Mean difference in counts


### PR DESCRIPTION
Rename 'x1' and 'x2' to 'g1' and 'g2'.  Consistent variables names make this
example work and produce the same results (-0.203874  3.363874) as shown
in the slide.  It depends on code from the previous example that loads
the sleep dataset and prepares 'g1' and 'g2'.
