### PR TITLE
update ggpairs call

### DIFF
--- a/07_RegressionModels/02_02_multivariateExamples/index.Rmd
+++ b/07_RegressionModels/02_02_multivariateExamples/index.Rmd
@@ -48,7 +48,7 @@ All variables but Fertility give proportions of the population.
 
 ```{r, fig.height=6, fig.width=10, echo = FALSE}
 require(datasets); data(swiss); require(GGally); require(ggplot2)
-g = ggpairs(swiss, lower = list(continuous = "smooth"),params = c(method = "loess"))
+g = wrap(ggpairs(swiss, lower = list(continuous = "smooth")), params = c(method = "loess"))
 g
 ```
 


### PR DESCRIPTION
when tried to reproduce on R 3.3.2 the error was thrown saying
"Error in stop_if_params_exist(params) : 
  'params' is a deprecated argument.  Please 'wrap' the function to supply arguments. help("wrap", package = "GGally")"
apparently we have to use 'wrap' function now with ggpairs