### PR TITLE
Math typo, line 79: \eta needs to be exponentiated

### DIFF
--- a/07_RegressionModels/03_01_glms/index.Rmd
+++ b/07_RegressionModels/03_01_glms/index.Rmd
@@ -76,7 +76,7 @@ Thus the likelihood is
 $$
 \prod_{i=1}^n \mu_i^{y_i} (1 - \mu_i)^{1-y_i}
 = \exp\left(\sum_{i=1}^n y_i \eta_i \right)
-\prod_{i=1}^n (1 + \eta_i)^{-1}
+\prod_{i=1}^n (1 + \exp(\eta_i))^{-1}
 $$
 
 ---


### PR DESCRIPTION
For correct math, one should change "(1 + \eta_i)^{-1}" to "(1 + \exp(\eta_i))^{-1}" on line 79 of 07/RegressionModels/03_01_glms/index.Rmd and in the slides using on Coursera.