### PR TITLE
Change subscript of X_{ik} to X_{ki} to make it consistent with lhs.

### DIFF
--- a/07_RegressionModels/02_01_multivariate/index.Rmd
+++ b/07_RegressionModels/02_01_multivariate/index.Rmd
@@ -135,7 +135,7 @@ $$
 
 $$
 E[Y | X_1 = x_1 + 1, \ldots, X_p = x_p]  - E[Y | X_1 = x_1, \ldots, X_p = x_p]$$
-$$= (x_1 + 1) \beta_1 + \sum_{k=2}^p x_{k} \beta_k + \sum_{k=1}^p x_{k} \beta_k = \beta_1 $$
+$$= (x_1 + 1) \beta_1 + \sum_{k=2}^p x_{k} \beta_k - \sum_{k=1}^p x_{k} \beta_k = \beta_1 $$
 So that the interpretation of a multivariate regression coefficient is the expected change in the response per unit change in the regressor, holding all of the other regressors fixed.
 
 In the next lecture, we'll do examples and go over context-specific

--- a/07_RegressionModels/02_01_multivariate/index.Rmd
+++ b/07_RegressionModels/02_01_multivariate/index.Rmd
@@ -54,7 +54,7 @@ by adding terms linearly into the model.
 $$
 Y_i =  \beta_1 X_{1i} + \beta_2 X_{2i} + \ldots +
 \beta_{p} X_{pi} + \epsilon_{i} 
-= \sum_{k=1}^p X_{ik} \beta_j + \epsilon_{i}
+= \sum_{k=1}^p X_{ki} \beta_j + \epsilon_{i}
 $$
 * Here $X_{1i}=1$ typically, so that an intercept is included.
 * Least squares (and hence ML estimates under iid Gaussianity 
@@ -144,8 +144,8 @@ interpretations.
 ---
 ## Fitted values, residuals and residual variation
 All of our SLR quantities can be extended to linear models
-* Model $Y_i = \sum_{k=1}^p X_{ik} \beta_{k} + \epsilon_{i}$ where $\epsilon_i \sim N(0, \sigma^2)$
-* Fitted responses $\hat Y_i = \sum_{k=1}^p X_{ik} \hat \beta_{k}$
+* Model $Y_i = \sum_{k=1}^p X_{ki} \beta_{k} + \epsilon_{i}$ where $\epsilon_i \sim N(0, \sigma^2)$
+* Fitted responses $\hat Y_i = \sum_{k=1}^p X_{ki} \hat \beta_{k}$
 * Residuals $e_i = Y_i - \hat Y_i$
 * Variance estimate $\hat \sigma^2 = \frac{1}{n-p} \sum_{i=1}^n e_i ^2$
 * To get predicted responses at new values, $x_1, \ldots, x_p$, simply plug them into the linear model $\sum_{k=1}^p x_{k} \hat \beta_{k}$

--- a/07_RegressionModels/02_01_multivariate/index.html
+++ b/07_RegressionModels/02_01_multivariate/index.html
@@ -108,7 +108,7 @@ by adding terms linearly into the model.
 \[
 Y_i =  \beta_1 X_{1i} + \beta_2 X_{2i} + \ldots +
 \beta_{p} X_{pi} + \epsilon_{i} 
-= \sum_{k=1}^p X_{ik} \beta_j + \epsilon_{i}
+= \sum_{k=1}^p X_{ki} \beta_j + \epsilon_{i}
 \]</li>
 <li>Here \(X_{1i}=1\) typically, so that an intercept is included.</li>
 <li>Least squares (and hence ML estimates under iid Gaussianity 
@@ -280,8 +280,8 @@ interpretations.</p>
     <p>All of our SLR quantities can be extended to linear models</p>
 
 <ul>
-<li>Model \(Y_i = \sum_{k=1}^p X_{ik} \beta_{k} + \epsilon_{i}\) where \(\epsilon_i \sim N(0, \sigma^2)\)</li>
-<li>Fitted responses \(\hat Y_i = \sum_{k=1}^p X_{ik} \hat \beta_{k}\)</li>
+<li>Model \(Y_i = \sum_{k=1}^p X_{ki} \beta_{k} + \epsilon_{i}\) where \(\epsilon_i \sim N(0, \sigma^2)\)</li>
+<li>Fitted responses \(\hat Y_i = \sum_{k=1}^p X_{ki} \hat \beta_{k}\)</li>
 <li>Residuals \(e_i = Y_i - \hat Y_i\)</li>
 <li>Variance estimate \(\hat \sigma^2 = \frac{1}{n-p} \sum_{i=1}^n e_i ^2\)</li>
 <li>To get predicted responses at new values, \(x_1, \ldots, x_p\), simply plug them into the linear model \(\sum_{k=1}^p x_{k} \hat \beta_{k}\)</li>

--- a/07_RegressionModels/02_01_multivariate/index.html
+++ b/07_RegressionModels/02_01_multivariate/index.html
@@ -262,7 +262,7 @@ E[Y | X_1 = x_1 + 1, \ldots, X_p = x_p] = (x_1 + 1) \beta_1 + \sum_{k=2}^p x_{k}
 
 <p>\[
 E[Y | X_1 = x_1 + 1, \ldots, X_p = x_p]  - E[Y | X_1 = x_1, \ldots, X_p = x_p]\]
-\[= (x_1 + 1) \beta_1 + \sum_{k=2}^p x_{k} \beta_k + \sum_{k=1}^p x_{k} \beta_k = \beta_1 \]
+\[= (x_1 + 1) \beta_1 + \sum_{k=2}^p x_{k} \beta_k - \sum_{k=1}^p x_{k} \beta_k = \beta_1 \]
 So that the interpretation of a multivariate regression coefficient is the expected change in the response per unit change in the regressor, holding all of the other regressors fixed.</p>
 
 <p>In the next lecture, we&#39;ll do examples and go over context-specific

--- a/07_RegressionModels/02_01_multivariate/index.md
+++ b/07_RegressionModels/02_01_multivariate/index.md
@@ -152,7 +152,7 @@ $$
 
 $$
 E[Y | X_1 = x_1 + 1, \ldots, X_p = x_p]  - E[Y | X_1 = x_1, \ldots, X_p = x_p]$$
-$$= (x_1 + 1) \beta_1 + \sum_{k=2}^p x_{k} \beta_k + \sum_{k=1}^p x_{k} \beta_k = \beta_1 $$
+$$= (x_1 + 1) \beta_1 + \sum_{k=2}^p x_{k} \beta_k - \sum_{k=1}^p x_{k} \beta_k = \beta_1 $$
 So that the interpretation of a multivariate regression coefficient is the expected change in the response per unit change in the regressor, holding all of the other regressors fixed.
 
 In the next lecture, we'll do examples and go over context-specific

--- a/07_RegressionModels/02_01_multivariate/index.md
+++ b/07_RegressionModels/02_01_multivariate/index.md
@@ -50,7 +50,7 @@ by adding terms linearly into the model.
 $$
 Y_i =  \beta_1 X_{1i} + \beta_2 X_{2i} + \ldots +
 \beta_{p} X_{pi} + \epsilon_{i} 
-= \sum_{k=1}^p X_{ik} \beta_j + \epsilon_{i}
+= \sum_{k=1}^p X_{ki} \beta_j + \epsilon_{i}
 $$
 * Here $X_{1i}=1$ typically, so that an intercept is included.
 * Least squares (and hence ML estimates under iid Gaussianity 
@@ -161,8 +161,8 @@ interpretations.
 ---
 ## Fitted values, residuals and residual variation
 All of our SLR quantities can be extended to linear models
-* Model $Y_i = \sum_{k=1}^p X_{ik} \beta_{k} + \epsilon_{i}$ where $\epsilon_i \sim N(0, \sigma^2)$
-* Fitted responses $\hat Y_i = \sum_{k=1}^p X_{ik} \hat \beta_{k}$
+* Model $Y_i = \sum_{k=1}^p X_{ki} \beta_{k} + \epsilon_{i}$ where $\epsilon_i \sim N(0, \sigma^2)$
+* Fitted responses $\hat Y_i = \sum_{k=1}^p X_{ki} \hat \beta_{k}$
 * Residuals $e_i = Y_i - \hat Y_i$
 * Variance estimate $\hat \sigma^2 = \frac{1}{n-p} \sum_{i=1}^n e_i ^2$
 * To get predicted responses at new values, $x_1, \ldots, x_p$, simply plug them into the linear model $\sum_{k=1}^p x_{k} \hat \beta_{k}$


### PR DESCRIPTION
In formulas the term X_{ik} is changed to X_{ki}.

Example:

 Y_i =  \beta_1 X_{1i} + \beta_2 X_{2i} + \ldots + \beta_{p} X_{pi} + \epsilon_{i} 
= \sum_{k=1}^p X_{ik} \beta_j + \epsilon_{i}

TO

 Y_i =  \beta_1 X_{1i} + \beta_2 X_{2i} + \ldots + \beta_{p} X_{pi} + \epsilon_{i} 
= \sum_{k=1}^p X_{ki} \beta_j + \epsilon_{i}