### PR TITLE
Proposing minor changes to code typos

### DIFF
--- a/06_StatisticalInference/08_tCIs/index.Rmd
+++ b/06_StatisticalInference/08_tCIs/index.Rmd
@@ -178,7 +178,7 @@ sp <- sqrt((7 * 15.34^2 + 20 * 18.23^2) / (8 + 21 - 2))
 ## Mistakenly treating the sleep data as grouped
 ```{r}
 n1 <- length(g1); n2 <- length(g2)
-sp <- sqrt( ((n1 - 1) * sd(x1)^2 + (n2-1) * sd(x2)^2) / (n1 + n2-2))
+sp <- sqrt( ((n1 - 1) * sd(g1)^2 + (n2-1) * sd(g2)^2) / (n1 + n2-2))
 md <- mean(g2) - mean(g1)
 semd <- sp * sqrt(1 / n1 + 1/n2)
 rbind(


### PR DESCRIPTION
x1 and x2 variables were changed to g1 and g2 variables in a line 2 of the following code chunk to make it work:

## Mistakenly treating the sleep data as grouped
```{r}
n1 <- length(g1); n2 <- length(g2)
sp <- sqrt( ((n1 - 1) * sd(g1)^2 + (n2-1) * sd(g2)^2) / (n1 + n2-2))